### PR TITLE
fix: scriptName + improving usage messages

### DIFF
--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -41,7 +41,7 @@ as you want/need to. Nobody can ask any more of you than that.
 As a maintainer, you're fine to make your branches on the main repo or on your own fork. Either
 way is fine.
 
-When we receive a pull request, a GitHub Actions build is kicked off automatically (see the `.github/`
+When we receive a pull request, a Circle CI build is kicked off automatically (see the `.circleci/`
 directory for what runs in the CI pipeline). We avoid merging anything that breaks the CI pipeline.
 
 Please review PRs and focus on the code rather than the individual. You never know when this is
@@ -56,7 +56,7 @@ about that.
 
 ## Release
 
-Our releases are automatic. They happen whenever code lands into `master`. A GitHub Actions build
+Our releases are automatic. They happen whenever code lands into `master`. A Circle CI build
 build gets kicked off and if it's successful, a tool called
 [`semantic-release`](https://github.com/semantic-release/semantic-release) is used to
 automatically publish a new release to npm as well as a changelog to GitHub. It is only able to

--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -41,8 +41,8 @@ as you want/need to. Nobody can ask any more of you than that.
 As a maintainer, you're fine to make your branches on the main repo or on your own fork. Either
 way is fine.
 
-When we receive a pull request, a travis build is kicked off automatically (see the `.travis.yml`
-for what runs in the travis build). We avoid merging anything that breaks the travis build.
+When we receive a pull request, a GitHub Actions build is kicked off automatically (see the `.github/`
+directory for what runs in the CI pipeline). We avoid merging anything that breaks the CI pipeline.
 
 Please review PRs and focus on the code rather than the individual. You never know when this is
 someone's first ever PR and we want their experience to be as positive as possible, so be
@@ -56,8 +56,8 @@ about that.
 
 ## Release
 
-Our releases are automatic. They happen whenever code lands into `master`. A travis build gets
-kicked off and if it's successful, a tool called
+Our releases are automatic. They happen whenever code lands into `master`. A GitHub Actions build
+build gets kicked off and if it's successful, a tool called
 [`semantic-release`](https://github.com/semantic-release/semantic-release) is used to
 automatically publish a new release to npm as well as a changelog to GitHub. It is only able to
 determine the version and whether a release is necessary by the git commit messages. With this

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "kcd-scripts test",
     "validate": "kcd-scripts validate",
     "commit": "git-cz",
-    "start": "node ./dist/cli.js",
+    "start": "./dist/cli.js",
     "dev": "./src/cli.js"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "kcd-scripts test",
     "validate": "kcd-scripts validate",
     "commit": "git-cz",
-    "start": "./dist/cli.js",
+    "start": "node ./dist/cli.js",
     "dev": "./src/cli.js"
   },
   "husky": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -16,22 +16,18 @@ const cwd = process.cwd()
 const defaultRCFile = path.join(cwd, '.all-contributorsrc')
 
 const yargv = yargs
+  .scriptName('all-contributors')
   .help('help')
   .alias('h', 'help')
   .alias('v', 'version')
   .version()
   .recommendCommands()
-  .command('generate', 'Generate the list of contributors')
-  .usage('Usage: $0 generate')
-  .command('add', 'add a new contributor')
-  .usage('Usage: $0 add <username> <contribution>')
-  .command('init', 'Prepare the project to be used with this tool')
-  .usage('Usage: $0 init')
+  .command('generate', `Generate the list of contributors\n\nUSAGE: all-contributors generate`)
+  .command('add', `Add a new contributor\n\nUSAGE: all-contributors add <username> <comma-separated contributions>`)
+  .command('init', `Prepare the project to be used with this tool\n\nUSAGE: all-contributors init`)
   .command(
     'check',
-    'Compares contributors from the repository with the ones credited in .all-contributorsrc',
-  )
-  .usage('Usage: $0 check')
+    `Compare contributors from the repository with the ones credited in .all-contributorsrc'\n\nUSAGE: all-contributors check`)
   .boolean('commit')
   .default('files', ['README.md'])
   .default('contributorsPerLine', 7)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: CLI usage was specified in the code, but in a wrong way.
This PR allows for the subcommands usage message to be displayed properly.
It also replace `cli.js` by `all-contributors` in the usage messages.

<!-- Why are these changes necessary? -->
**Why**: in order to fix the aforementioned usage message issues

<!-- How were these changes implemented? -->
**How**: in Javascript 😊

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation **N/A**
- [ ] Tests **N/A**
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
**Behaviour BEFORE** this PR:
```
$ all-contributors add --help

add a new contributor

Options :
...
```

**Behaviour AFTER** this PR:
```
$ all-contributors add --help

Add a new contributor

USAGE: all-contributors add <username> <comma-separated contributions>

Options :
...
```

My initial motivation for this PR was to make it explicit in `all-contributors add --help`
that several contributions could be specified at once,
but **comma-separated and not space-separated**,
as I have been confused myself by this.