### PR TITLE
fix: trim `nextLink` before slicing

### DIFF
--- a/src/repo/github.js
+++ b/src/repo/github.js
@@ -45,7 +45,7 @@ function getNextLink(link) {
     return null
   }
 
-  return nextLink.split(';')[0].slice(1, -1)
+  return nextLink.split(';')[0].trim().slice(1, -1)
 }
 
 function getContributorsPage(githubUrl, optionalPrivateToken) {


### PR DESCRIPTION
Hey all! I think I found and fixed a small bug; using this PR to start a discussion. When I tried updating Redwood's all contributors table, I got a `Only absolute URLs are supported` error, so I dug in a bit. This is the command I ran:
```
yarn all-contributors check --config .all-contributorsrc
```

And here's the `.all-contributorsrc` file: https://github.com/redwoodjs/redwood/blob/main/tasks/all-contributors/.all-contributorsrc.

I stepped through the code and narrowed it down; the error's happening in the `getNextLink` function. Here's the value for `link`:

```js
'<https://api.github.com/repositories/191051391/contributors?per_page=100&page=1>; rel="prev", <https://api.github.com/repositories/191051391/contributors?per_page=100&page=3>; rel="next", <https://api.github.com/repositories/191051391/contributors?per_page=100&page=3>; rel="last", <https://api.github.com/repositories/191051391/contributors?per_page=100&page=1>; rel="first"'
```

The function splits `link` on commas and looks for `rel=next`. In this case, it's the second link. So splitting it results in:

```js
// Note the space
' <https://api.github.com/repositories/191051391/contributors?per_page=100&page=3>; rel="next"'
```

That means the next call (`return nextLink.split(';')[0].slice(1, -1);`) results in:

```js
// We got rid of the space, but < remains
'<https://api.github.com/repositories/191051391/contributors?per_page=100&page=3'
```

When another function tries to fetch this link, it throws.

It seems like all we need to do is trim the string before slicing, but let me know what you think!