### PR TITLE
feat: use Prettier to write config file, if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "nock": "^12.0.0",
     "semantic-release": "^17.0.8"
   },
+  "optionalDependencies": {
+    "prettier": "^2"
+  },
   "eslintIgnore": [
     "node_modules",
     "coverage",

--- a/src/util/__tests__/__stubs__/.prettierrc.json
+++ b/src/util/__tests__/__stubs__/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+	"useTabs": true
+}

--- a/src/util/__tests__/formatting.js
+++ b/src/util/__tests__/formatting.js
@@ -1,0 +1,35 @@
+import path from 'path'
+import formatting from '../formatting'
+
+const content = {contributors: [{id: 'abc123'}]}
+
+const absentFile = '/!@#*&^DefinitelyDoesNotExistAllContributorsCLI$!@#'
+const absentConfigFileExpected = `{
+  "contributors": [
+    {
+      "id": "abc123"
+    }
+  ]
+}`
+
+const presentFile = path.join(__dirname, '__stubs__', 'file.json')
+const presentConfigFileExpected = `{
+	"contributors": [
+		{
+			"id": "abc123"
+		}
+	]
+}
+`
+
+test('falls back to JSON.stringify when the configPath cannot resolve to a config', () => {
+  expect(formatting.formatConfig(absentFile, content)).toBe(
+    absentConfigFileExpected,
+  )
+})
+
+test('uses Prettier when the configPath can resolve to a config', () => {
+  expect(formatting.formatConfig(presentFile, content)).toBe(
+    presentConfigFileExpected,
+  )
+})

--- a/src/util/config-file.js
+++ b/src/util/config-file.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const pify = require('pify')
 const _ = require('lodash/fp')
 const jf = require('json-fixer')
+const {formatConfig} = require('./formatting')
 
 function readConfig(configPath) {
   try {
@@ -14,7 +15,7 @@ function readConfig(configPath) {
     }
     if (changed) {
       //Updates the file with fixes
-      fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+      fs.writeFileSync(configPath, formatConfig(config))
     }
     return config
   } catch (error) {
@@ -43,7 +44,7 @@ function writeConfig(configPath, content) {
       `Error! Project files was overridden and is empty in ${configPath}`,
     )
   }
-  return pify(fs.writeFile)(configPath, `${JSON.stringify(content, null, 2)}\n`)
+  return pify(fs.writeFile)(configPath, `${formatConfig(content)}\n`)
 }
 
 function writeContributors(configPath, contributors) {

--- a/src/util/formatting.js
+++ b/src/util/formatting.js
@@ -1,0 +1,21 @@
+function formatConfig(configPath, content) {
+  const stringified = JSON.stringify(content, null, 2)
+  try {
+    const prettier = require('prettier')
+    const prettierConfig = prettier.resolveConfig.sync(configPath, {
+      useCache: false,
+    })
+
+    return prettierConfig
+      ? prettier.format(stringified, {...prettierConfig, parser: 'json'})
+      : stringified
+  } catch (error) {
+    // If Prettier can't be required or throws in general,
+    // assume it's not usable and we should fall back to JSON.stringify
+    return stringified
+  }
+}
+
+module.exports = {
+  formatConfig,
+}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: If the user has the `prettier` package available in their project _and_ has a Prettier config file (e.g. `.prettierrc.json`), [Prettier](https://prettier.io) will be used to write `.allcontributorsrc` files.

<!-- Why are these changes necessary? -->
**Why**: See #347. 

<!-- How were these changes implemented? -->
**How**: Adds `prettier` as an optional dependency. Augments the config writing logic to:
1. Attempt to `require('prettier')`
2. Find the nearest Prettier config for the file with `prettier.resolveConfigFile.sync`
3. Use Prettier to format the file with that config
...falling back to the traditional `JSON.stringify(content, null, 2)` if any of that fails.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

Are `optionalDependencies` the way to go? I can never keep track of the latest preferences around optionals/peers/etc.
