### PR TITLE
fix: content not returned anymore by add

### DIFF
--- a/src/util/__tests__/formatting.js
+++ b/src/util/__tests__/formatting.js
@@ -23,13 +23,13 @@ const presentConfigFileExpected = `{
 `
 
 test('falls back to JSON.stringify when the configPath cannot resolve to a config', () => {
-  expect(formatting.formatConfig(absentFile, content)).toBe(
+  expect(formatting.formatConfig(content, absentFile)).toBe(
     absentConfigFileExpected,
   )
 })
 
 test('uses Prettier when the configPath can resolve to a config', () => {
-  expect(formatting.formatConfig(presentFile, content)).toBe(
+  expect(formatting.formatConfig(content, presentFile)).toBe(
     presentConfigFileExpected,
   )
 })

--- a/src/util/formatting.js
+++ b/src/util/formatting.js
@@ -1,4 +1,4 @@
-function formatConfig(configPath, content) {
+function formatConfig(content, configPath) {
   const stringified = JSON.stringify(content, null, 2)
   try {
     const prettier = require('prettier')


### PR DESCRIPTION

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Fixing `contributor add`. Currently it produces files containing the string "undefined" instead of the JSON content.

<!-- Why are these changes necessary? -->
**Why**:

The change https://github.com/all-contributors/cli/pull/356 seem to break the formatting of the file .all-contributorsrc. Instead of formatting the content, it formats "undefined".

See:
- https://github.com/all-contributors/cli/pull/356#discussion_r1254750887
- https://github.com/all-contributors/cli/pull/356#issuecomment-1624086273


<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
