### PR TITLE
fix: incorrectly formatted URLs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -490,6 +490,13 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/6765735?v=4",
       "profile": "https://github.com/schweden1997",
       "contributions": ["bug"]
+    },
+    {
+      "login": "KibbeWater",
+      "name": "Snow",
+      "avatar_url": "https://avatars.githubusercontent.com/u/35224538?v=4",
+      "profile": "https://kibbewater.com",
+      "contributions": ["code", "bug"]
     }
   ],
   "skipCi": true,

--- a/src/generate/__tests__/format-contributor.js
+++ b/src/generate/__tests__/format-contributor.js
@@ -20,7 +20,7 @@ test('format a simple contributor', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -30,7 +30,7 @@ test('format contributor with complex contribution types', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=kentcdodds" title="Documentation">📖</a> <a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a> <a href="#question-kentcdodds" title="Answering Questions">💬</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=kentcdodds" title="Documentation">📖</a> <a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a> <a href="#question-kentcdodds" title="Answering Questions">💬</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -53,7 +53,7 @@ test('default image size to 100', () => {
   delete options.imageSize
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?s=100" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684?size=100" width="100px" height="100px" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -63,7 +63,7 @@ test('format contributor with pipes in their name', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://github.com/chrisinajar"><img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="Who &#124; Needs &#124; Pipes?"/><br /><sub><b>Who &#124; Needs &#124; Pipes?</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=pipey" title="Documentation">📖</a>'
+    '<a href="http://github.com/chrisinajar"><img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="Who &#124; Needs &#124; Pipes?"/><br /><sub><b>Who &#124; Needs &#124; Pipes?</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=pipey" title="Documentation">📖</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -73,7 +73,7 @@ test('format contributor with no GitHub account', () => {
   const {options} = fixtures()
 
   const expected =
-    '<img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="No Github Account"/><br /><sub><b>No Github Account</b></sub><br /><a href="#translation" title="Translation">🌍</a>'
+    '<img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="No Github Account"/><br /><sub><b>No Github Account</b></sub><br /><a href="#translation" title="Translation">🌍</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -83,7 +83,7 @@ test('format contributor with no complete name', () => {
   const {options} = fixtures()
 
   const expected =
-    '<img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="nocompletename"/><br /><sub><b>nocompletename</b></sub><br /><a href="#translation-nocompletename" title="Translation">🌍</a>'
+    '<img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="nocompletename"/><br /><sub><b>nocompletename</b></sub><br /><a href="#translation-nocompletename" title="Translation">🌍</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -93,6 +93,6 @@ test('format contributor with quotes in name', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://github.com/namelastname"><img src="https://avatars1.githubusercontent.com/u/1500684?s=150" width="150px;" alt="Name &quot;Nickname&quot; Lastname"/><br /><sub><b>Name &quot;Nickname&quot; Lastname</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=namelastname" title="Documentation">📖</a>'
+    '<a href="http://github.com/namelastname"><img src="https://avatars1.githubusercontent.com/u/1500684?size=150" width="150px" height="150px" alt="Name &quot;Nickname&quot; Lastname"/><br /><sub><b>Name &quot;Nickname&quot; Lastname</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=namelastname" title="Documentation">📖</a>'
   expect(formatContributor(options, contributor)).toBe(expected)
 })

--- a/src/generate/format-contributor.js
+++ b/src/generate/format-contributor.js
@@ -2,7 +2,7 @@ const _ = require('lodash/fp')
 const formatContributionType = require('./format-contribution-type')
 
 const avatarTemplate = _.template(
-  '<img src="<%= contributor.avatar_url %>?s=<%= options.imageSize %>" width="<%= options.imageSize %>px;" alt="<%= name %>"/>',
+  '<img src="<%= contributor.avatar_url %>" width="<%= options.imageSize %>px" height="<%= options.imageSize %>px" alt="<%= name %>"/>',
 )
 const avatarBlockTemplate = _.template(
   '<a href="<%= contributor.profile %>"><%= avatar %><br /><sub><b><%= name %></b></sub></a>',
@@ -52,9 +52,19 @@ function escapeName(name) {
 module.exports = function formatContributor(options, contributor) {
   const formatter = _.partial(formatContributionType, [options, contributor])
   const contributions = contributor.contributions.map(formatter).join(' ')
+
+  const contributorAvatarUrl = new URL(contributor.avatar_url)
+  contributorAvatarUrl.searchParams.append(
+    'size',
+    options.imageSize ?? defaultImageSize,
+  )
+
   const templateData = {
     contributions,
-    contributor,
+    contributor: {
+      ...contributor,
+      avatar_url: contributorAvatarUrl.toString(),
+    },
     options: _.assign({imageSize: defaultImageSize}, options),
   }
   const customTemplate =


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Fixed a bug where URLs may be malformed and an additonal bug which improved CLS on generated files

<!-- Why are these changes necessary? -->
**Why**: Newer GitHub URLs may come with a ?v=4 query already, making these URLs malformed causing errors and incorrect sizings. This will size images properly, saving on data and web load times. There is also a fix to reduce the CLS by defining the width and height of the image.

<!-- How were these changes implemented? -->
**How**: URLs are being formatted with the URL class to ensure URL safety.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation (N/A)
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
