### PR TITLE
chore(ci): setup trusted publishing

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -65,4 +65,4 @@ jobs:
       - run: |
           npm ci
           npm run build
-      - run: npm publish --provenance
+      - run: npm publish


### PR DESCRIPTION
This pr closes #454 

**What**:
I have done the following
* on NPM i setup OIDC / Trusted Publishing and disabled tokens for the time being (safer)
* Added a secure environment to the publish step (which is triggered on release) and added the maintainer team to have access to "approve" the final publish step. If we decide this is cumbersome, we can remove it. 
* Setup this action to run after tests but only on a release. We could have a totally separate deploy action if folks prefer that. i should i could use artifacts and such but it didn't work out quite the way i wanted it to. 


**How**:

* https://docs.npmjs.com/generating-provenance-statements 
Supports sigstore and signed releases.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
