### PR TITLE
fix: Ignore linting of .all-contributorsrc file and the CHANGELOG file

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,12 @@ import vitestPlugin from 'eslint-plugin-vitest'
 import globals from 'globals'
 
 export default defineConfig([
-  globalIgnores(['coverage/**', 'dist/**']),
+  globalIgnores([
+    'coverage/**',
+    'dist/**',
+    '.all-contributorsrc',
+    'CHANGELOG*',
+  ]),
   {linterOptions: {reportUnusedDisableDirectives: 'error'}},
   {
     extends: [js.configs.recommended, importPlugin.flatConfigs.recommended],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  Ignore these two files from the linting rules

<!-- Why are these changes necessary? -->

**Why**: The all-contributors bot and the release please pipeline generate content for these two respective files, but they do not follow the repos linting convention. While we could add an additional lint step after each of these actions, it is far simpler to ignore them from the linting rules for the time being.

<!-- How were these changes implemented? -->

**How**: Add them to the eslint ignore list

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
