### PR TITLE
chore(ci): allow deploy for release candidate

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   release:
-    types: [published]
+    types: [published, prereleased]
 
 permissions: {}
 


### PR DESCRIPTION
This is a tiny change as I didn't support prereleases in our deploy workflow. So this fixes that. I'll try again to publish a prerelease after this. I am going to merge this without a review. 

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
