### PR TITLE
fix: Update NPM and also node to ensure trusted publishing works

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest


### PR DESCRIPTION
I wish there was another way to test this - it looks like node v22.x ships with npm 10.x but you need 11.x for trusted publishing to work. 

I found a few examples of this in [github issues and prs](https://github.com/MetroStar/comet/blob/7a9cce0013196057881990aeddbaafdaa6c9fadc/.github/workflows/publish-package.yaml#L35) and also [this post.](https://medium.com/@kenricktan11/npm-trusted-publishers-the-weird-404-error-and-the-node-js-24-fix-a9f1d717a5dd)

So this updates those items to see if the handshake will then work as expected.  

I have triple checked permissions at this point. 

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
