### PR TITLE
fix: add tag for pre release (@next) vs release (@latest)

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   workflow_dispatch:
   release:
-    types: [published, prereleased]
+    types: [released, prereleased]
 
 permissions: {}
 
@@ -63,9 +63,16 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       # Ensure npm 11.5.1 or later for trusted publishing
-      - run: npm install -g npm@latest
-      - run: |
-          npm --version
+      - name: Install latest version of npm
+        run: npm install -g npm@latest
+      - name: Install deps and build package
+        run: |
           npm ci
           npm run build
-      - run: npm publish --provenance
+      - name: Publish to NPM via trusted publishing (tag next if prerelease)
+        run: |
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
+            npm publish --provenance --tag next
+          else
+            npm publish --provenance
+          fi


### PR DESCRIPTION
Phew, so the node also requires a tag when publishing a prerelease to avoid defaulting to latest, which we don't want. so this cleans up a few things

✅ The build triggers on both a release and a prerelease. (it was triggering twice previously)
✅ Then the action figures out if this is a prerelease, publish, but add the tag "next" otherwise latest

NPM is recognizing the handshake now so it's just a matter of getting the tags right (i think). 

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
